### PR TITLE
Implement inmemory node provider, file upload/downloader

### DIFF
--- a/cmd/labapp/command/root.go
+++ b/cmd/labapp/command/root.go
@@ -43,6 +43,12 @@ func App(ctx context.Context) *cli.App {
 			EnvVar: "LABAPP_ADDRESS",
 		},
 		cli.StringFlag{
+			Name:  "libp2p-address",
+			Usage: "address for libp2p",
+			Value: "/ip4/0.0.0.0/tcp/0",
+			EnvVar: "LABAPP_LIBP2P_ADDRESS",
+		},
+		cli.StringFlag{
 			Name:  "log-level,l",
 			Usage: "set the logging level [debug, info, warn, error, fatal, panic, none]",
 			Value: "debug",
@@ -65,7 +71,7 @@ func appAction(c *cli.Context) error {
 	}
 
 	ctx := cliutil.CommandContext(c)
-	app, err := labapp.New(root, c.GlobalString("address"), zerolog.Ctx(ctx))
+	app, err := labapp.New(root, c.GlobalString("address"), c.GlobalString("libp2p-address"), zerolog.Ctx(ctx))
 	if err != nil {
 		return err
 	}

--- a/cmd/ociadd/main.go
+++ b/cmd/ociadd/main.go
@@ -54,7 +54,7 @@ func run(ref string) error {
 	defer cancel()
 
 	root := "./tmp/ociadd"
-	p, err := peer.New(ctx, filepath.Join(root, "peer"))
+	p, err := peer.New(ctx, filepath.Join(root, "peer"), "/ip4/0.0.0.0/tcp/0")
 	if err != nil {
 		return err
 	}

--- a/cmd/ociget/main.go
+++ b/cmd/ociget/main.go
@@ -58,7 +58,7 @@ func run(addr, ref string) error {
 	defer cancel()
 
 	root := "./tmp/ociget"
-	p, err := peer.New(ctx, filepath.Join(root, "peer"))
+	p, err := peer.New(ctx, filepath.Join(root, "peer"), "/ip4/0.0.0.0/tcp/0")
 	if err != nil {
 		return err
 	}

--- a/downloaders/downloaders.go
+++ b/downloaders/downloaders.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/Netflix/p2plab"
+	"github.com/Netflix/p2plab/downloaders/filedownloader"
 	"github.com/Netflix/p2plab/downloaders/httpdownloader"
 	"github.com/Netflix/p2plab/downloaders/s3downloader"
 	"github.com/Netflix/p2plab/pkg/httputil"
@@ -64,10 +65,12 @@ func (f *Downloaders) Get(downloaderType string) (p2plab.Downloader, error) {
 func (f *Downloaders) newDownloader(downloaderType string) (p2plab.Downloader, error) {
 	// root := filepath.Join(f.root, downloaderType)
 	switch downloaderType {
-	case "s3":
-		return s3downloader.New(f.settings.Client.HTTPClient, f.settings.S3)
+	case "file":
+		return filedownloader.New(), nil
 	case "http", "https":
 		return httpdownloader.New(f.settings.Client), nil
+	case "s3":
+		return s3downloader.New(f.settings.Client.HTTPClient, f.settings.S3)
 	default:
 		return nil, errors.Errorf("unrecognized downloader type: %q", downloaderType)
 	}

--- a/downloaders/filedownloader/downloader.go
+++ b/downloaders/filedownloader/downloader.go
@@ -12,27 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package p2plab
+package filedownloader
 
 import (
 	"context"
 	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/Netflix/p2plab"
+	"github.com/Netflix/p2plab/errdefs"
+	"github.com/pkg/errors"
 )
 
-type Builder interface {
-	Init(ctx context.Context) error
-
-	Resolve(ctx context.Context, ref string)  (commit string, err error)
-
-	Build(ctx context.Context, commit string) (link string, err error)
+type downloader struct {
 }
 
-type Uploader interface {
-	Upload(ctx context.Context, r io.Reader) (link string, err error)
-
-	Close() error
+func New() p2plab.Downloader {
+	return &downloader{}
 }
 
-type Downloader interface {
-	Download(ctx context.Context, link string) (io.ReadCloser, error)
+func (f *downloader) Download(ctx context.Context, link string) (io.ReadCloser, error) {
+	u, err := url.Parse(link)
+	if err != nil {
+		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "invalid url %q", link)
+	}
+
+	downloadPath := filepath.Join(u.Host, u.Path)
+	return os.Open(downloadPath)
 }

--- a/downloaders/httpdownloader/downloader.go
+++ b/downloaders/httpdownloader/downloader.go
@@ -30,8 +30,8 @@ func New(client *httputil.Client) p2plab.Downloader {
 	return &downloader{client}
 }
 
-func (f *downloader) Download(ctx context.Context, ref string) (io.ReadCloser, error) {
-	req := f.client.NewRequest("GET", ref)
+func (f *downloader) Download(ctx context.Context, link string) (io.ReadCloser, error) {
+	req := f.client.NewRequest("GET", link)
 	resp, err := req.Send(ctx)
 	if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -56,8 +56,9 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pkg/errors v0.8.1
+	github.com/rs/xid v1.2.1
 	github.com/rs/zerolog v1.14.4-0.20190719171043-b806a5ecbe53
 	github.com/sirupsen/logrus v1.4.0 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/opencontainers/runc v1.0.0-rc8 // indirect
 	github.com/opentracing-contrib/go-stdlib v0.0.0-20190519235532-cf7a6c988dc9
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.14.4-0.20190719171043-b806a5ecbe53
 	github.com/sirupsen/logrus v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
+github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -762,6 +764,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/xid v1.2.1 h1:mhH9Nq+C1fY2l1XIpgxIiUOfNpRBYH1kKcr+qfKgjRc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.14.4-0.20190719171043-b806a5ecbe53 h1:SoPVnBDBNgsTpvoON2j4hOJL5EqNnczArbonNPHbcrw=
 github.com/rs/zerolog v1.14.4-0.20190719171043-b806a5ecbe53/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=

--- a/labapp/labapp.go
+++ b/labapp/labapp.go
@@ -30,10 +30,10 @@ type LabApp struct {
 	closers []io.Closer
 }
 
-func New(root, addr string, logger *zerolog.Logger) (*LabApp, error) {
+func New(root, addr, libp2pAddr string, logger *zerolog.Logger) (*LabApp, error) {
 	var closers []io.Closer
 	pctx, cancel := context.WithCancel(context.Background())
-	p, err := peer.New(pctx, root)
+	p, err := peer.New(pctx, root, libp2pAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/labd/controlapi/node.go
+++ b/labd/controlapi/node.go
@@ -122,8 +122,8 @@ type node struct {
 
 func NewNode(client *httputil.Client, m metadata.Node) p2plab.Node {
 	return &node{
-		AgentAPI: agentapi.New(client, fmt.Sprintf("http://%s:7002", m.Address)),
-		AppAPI:   appapi.New(client, fmt.Sprintf("http://%s:7003", m.Address)),
+		AgentAPI: agentapi.New(client, fmt.Sprintf("http://%s:%d", m.Address, m.AgentPort)),
+		AppAPI:   appapi.New(client, fmt.Sprintf("http://%s:%d", m.Address, m.AppPort)),
 		metadata: m,
 	}
 }

--- a/labd/settings.go
+++ b/labd/settings.go
@@ -22,10 +22,18 @@ import (
 type LabdOption func(*LabdSettings) error
 
 type LabdSettings struct {
+	Libp2pAddress    string
 	Provider         string
 	ProviderSettings providers.ProviderSettings
 	Uploader         string
 	UploaderSettings uploaders.UploaderSettings
+}
+
+func WithLibp2pAddress(addr string) LabdOption {
+	return func(s *LabdSettings) error {
+		s.Libp2pAddress = addr
+		return nil
+	}
 }
 
 func WithProvider(provider string) LabdOption {

--- a/metadata/buckets.go
+++ b/metadata/buckets.go
@@ -39,7 +39,9 @@ var (
 	bucketKeySource    = []byte("source")
 
 	// Node buckets.
-	bucketKeyAddress = []byte("address")
+	bucketKeyAddress   = []byte("address")
+	bucketKeyAgentPort = []byte("agentPort")
+	bucketKeyAppPort   = []byte("appPort")
 
 	// Build buckets
 	bucketKeyLink = []byte("link")
@@ -49,15 +51,15 @@ var (
 	bucketKeyScenario = []byte("scenario")
 	bucketKeyPlan     = []byte("plan")
 	bucketKeySubject  = []byte("subject")
-	bucketKeyReport  = []byte("report")
+	bucketKeyReport   = []byte("report")
 
 	// Common buckets.
-	bucketKeyID         = []byte("id")
-	bucketKeyStatus     = []byte("status")
-	bucketKeyLabels     = []byte("labels")
-	bucketKeyCreatedAt  = []byte("createdAt")
-	bucketKeyUpdatedAt  = []byte("updatedAt")
-	bucketKeyDefinition = []byte("definition")
+	bucketKeyID           = []byte("id")
+	bucketKeyStatus       = []byte("status")
+	bucketKeyLabels       = []byte("labels")
+	bucketKeyCreatedAt    = []byte("createdAt")
+	bucketKeyUpdatedAt    = []byte("updatedAt")
+	bucketKeyDefinition   = []byte("definition")
 	bucketKeyGitReference = []byte("gitReference")
 )
 

--- a/metadata/node.go
+++ b/metadata/node.go
@@ -16,6 +16,7 @@ package metadata
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/Netflix/p2plab/errdefs"
@@ -27,6 +28,10 @@ type Node struct {
 	ID string
 
 	Address string
+
+	AgentPort int
+
+	AppPort int
 
 	GitReference string
 
@@ -253,6 +258,10 @@ func readNode(bkt *bolt.Bucket, node *Node) error {
 			node.ID = string(v)
 		case string(bucketKeyAddress):
 			node.Address = string(v)
+		case string(bucketKeyAgentPort):
+			node.AgentPort, _ = strconv.Atoi(string(v))
+		case string(bucketKeyAppPort):
+			node.AppPort, _ = strconv.Atoi(string(v))
 		case string(bucketKeyGitReference):
 			node.GitReference = string(v)
 		}
@@ -275,6 +284,8 @@ func writeNode(bkt *bolt.Bucket, node *Node) error {
 	for _, f := range []field{
 		{bucketKeyID, []byte(node.ID)},
 		{bucketKeyAddress, []byte(node.Address)},
+		{bucketKeyAgentPort, []byte(strconv.Itoa(node.AgentPort))},
+		{bucketKeyAppPort, []byte(strconv.Itoa(node.AppPort))},
 		{bucketKeyGitReference, []byte(node.GitReference)},
 	} {
 		err = bkt.Put(f.key, f.value)

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -85,14 +85,14 @@ type Peer struct {
 	reporter metrics.Reporter
 }
 
-func New(ctx context.Context, root string) (*Peer, error) {
+func New(ctx context.Context, root, addr string) (*Peer, error) {
 	ds, err := NewDatastore(root)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create datastore")
 	}
 
 	reporter := metrics.NewBandwidthCounter()
-	h, r, err := NewLibp2pPeer(ctx, reporter)
+	h, r, err := NewLibp2pPeer(ctx, addr, reporter)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create libp2p peer")
 	}
@@ -307,7 +307,7 @@ func NewDatastore(path string) (datastore.Batching, error) {
 	return badger.NewDatastore(path, &badger.DefaultOptions)
 }
 
-func NewLibp2pPeer(ctx context.Context, reporter metrics.Reporter) (host.Host, routing.ContentRouting, error) {
+func NewLibp2pPeer(ctx context.Context, addr string, reporter metrics.Reporter) (host.Host, routing.ContentRouting, error) {
 	transports := libp2p.ChainOptions(
 		libp2p.Transport(tcp.NewTCPTransport),
 		libp2p.Transport(ws.New),
@@ -319,9 +319,7 @@ func NewLibp2pPeer(ctx context.Context, reporter metrics.Reporter) (host.Host, r
 
 	security := libp2p.Security(secio.ID, secio.New)
 
-	listenAddrs := libp2p.ListenAddrStrings(
-		"/ip4/0.0.0.0/tcp/4001",
-	)
+	listenAddrs := libp2p.ListenAddrStrings(addr)
 
 	bwReporter := libp2p.BandwidthReporter(reporter)
 

--- a/providers/inmemory/provider.go
+++ b/providers/inmemory/provider.go
@@ -1,0 +1,120 @@
+// Copyright 2019 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inmemory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Netflix/p2plab"
+	"github.com/Netflix/p2plab/labagent"
+	"github.com/Netflix/p2plab/metadata"
+	"github.com/rs/zerolog"
+)
+
+type provider struct {
+	root      string
+	nodes     map[string][]*node
+	logger    *zerolog.Logger
+	agentOpts []labagent.LabagentOption
+}
+
+func New(root string, logger *zerolog.Logger, agentOpts ...labagent.LabagentOption) (p2plab.NodeProvider, error) {
+	err := os.MkdirAll(root, 0711)
+	if err != nil {
+		return nil, err
+	}
+
+	return &provider{
+		root:      root,
+		nodes:     make(map[string][]*node),
+		logger:    logger,
+		agentOpts: agentOpts,
+	}, nil
+}
+
+func (p *provider) CreateNodeGroup(ctx context.Context, id string, cdef metadata.ClusterDefinition) (*p2plab.NodeGroup, error) {
+	var ns []metadata.Node
+	for _, group := range cdef.Groups {
+		n, err := newNode()
+		if err != nil {
+			return nil, err
+		}
+		p.nodes[id] = append(p.nodes[id], n)
+
+		ns = append(ns, metadata.Node{
+			ID:           n.ID,
+			Address:      "127.0.0.1",
+			AgentPort:    n.AgentPort,
+			AppPort:      n.AppPort,
+			GitReference: group.GitReference,
+			Labels: []string{
+				n.ID,
+				group.InstanceType,
+				group.Region,
+			},
+		})
+	}
+
+	return &p2plab.NodeGroup{
+		ID:    id,
+		Nodes: ns,
+	}, nil
+}
+
+func (p *provider) DestroyNodeGroup(ctx context.Context, ng *p2plab.NodeGroup) error {
+	return nil
+}
+
+type node struct {
+	ID        string
+	AgentPort int
+	AppPort   int
+	LabAgent  *labagent.LabAgent
+}
+
+func (p *provider) newNode() (*node, error) {
+	freePorts, err := freeport.GetFreePorts(2)
+	if err != nil {
+		return nil, err
+	}
+	agentPort, appPort := freePorts[0], freePorts[1]
+
+	id := xid.New()
+
+	agentRoot := filepath.Join(p.root, id, "labagent")
+	agentAddr := fmt.Sprintf(":%d", agentPort)
+
+	appRoot := filepath.Join(p.root, id, "labapp")
+	appAddr := fmt.Sprintf("http://localhost:%d", appPort)
+
+	la, err := labagent.New(agentRoot, agentAddr, appRoot, appAddr, p.logger, p.agentOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &node{
+		ID:        id,
+		AgentPort: agentPort,
+		AppPort:   appPort,
+		LabAgent:  la,
+	}, nil
+}
+
+func (n *node) Close() error {
+	return n.LabAgent.Close()
+}

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -18,17 +18,32 @@ import (
 	"path/filepath"
 
 	"github.com/Netflix/p2plab"
+	"github.com/Netflix/p2plab/downloaders"
+	"github.com/Netflix/p2plab/downloaders/s3downloader"
 	"github.com/Netflix/p2plab/errdefs"
+	"github.com/Netflix/p2plab/labagent"
+	"github.com/Netflix/p2plab/metadata"
+	"github.com/Netflix/p2plab/providers/inmemory"
 	"github.com/Netflix/p2plab/providers/terraform"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 type ProviderSettings struct {
+	DB     metadata.DB
+	Logger *zerolog.Logger
 }
 
 func GetNodeProvider(root, providerType string, settings ProviderSettings) (p2plab.NodeProvider, error) {
 	root = filepath.Join(root, providerType)
 	switch providerType {
+	case "inmemory":
+		return inmemory.New(root, settings.DB, settings.Logger, labagent.WithDownloaderSettings(downloaders.DownloaderSettings{
+			S3: s3downloader.S3DownloaderSettings{
+				Region: "us-west-2",
+			},
+		}),
+		)
 	case "terraform":
 		return terraform.New(root)
 	default:

--- a/providers/terraform/provider.go
+++ b/providers/terraform/provider.go
@@ -29,6 +29,11 @@ import (
 	"github.com/rs/zerolog"
 )
 
+var (
+	DefaultAgentPort = 7003
+	DefaultAppPort   = 7004
+)
+
 type provider struct {
 	root          string
 	tfvars        *template.Template

--- a/providers/terraform/terraform.go
+++ b/providers/terraform/terraform.go
@@ -87,6 +87,8 @@ func (t *Terraform) Apply(ctx context.Context, id string, cdef metadata.ClusterD
 			ns = append(ns, metadata.Node{
 				ID:           instance.InstanceId,
 				Address:      instance.PrivateIp,
+				AgentPort:    DefaultAgentPort,
+				AppPort:      DefaultAppPort,
 				GitReference: cg.GitReference,
 				Labels: append([]string{
 					instance.InstanceId,

--- a/uploaders/fileuploader/uploader.go
+++ b/uploaders/fileuploader/uploader.go
@@ -1,0 +1,123 @@
+// Copyright 2019 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileuploader
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Netflix/p2plab"
+	cid "github.com/ipfs/go-cid"
+	multihash "github.com/multiformats/go-multihash"
+	"github.com/rs/zerolog"
+)
+
+type FileUploaderSettings struct {
+	Address string
+}
+
+type uploader struct {
+	root       string
+	cancel     context.CancelFunc
+	cidBuilder cid.Builder
+}
+
+func New(root string, logger *zerolog.Logger, settings FileUploaderSettings) (p2plab.Uploader, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.MkdirAll(root, 0711)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &http.Server{
+		Handler:           http.FileServer(http.Dir(root)),
+		Addr:              settings.Address,
+		ReadHeaderTimeout: 20 * time.Second,
+		ReadTimeout:       1 * time.Minute,
+		WriteTimeout:      30 * time.Minute,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Done()
+		err := s.Shutdown(ctx)
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to shutdown fsuploader")
+		}
+	}()
+
+	go func() {
+		err := s.ListenAndServe()
+		if err != nil {
+			logger.Error().Err(err).Msg("failed to serve fsuploader")
+		}
+	}()
+
+	return &uploader{
+		root:       root,
+		cancel:     cancel,
+		cidBuilder: cid.V1Builder{MhType: multihash.SHA2_256},
+	}, nil
+}
+
+func (u *uploader) Close() error {
+	u.cancel()
+	return nil
+}
+
+func (u *uploader) Upload(ctx context.Context, r io.Reader) (link string, err error) {
+	content, err := ioutil.ReadAll(r)
+	if err != nil {
+		return "", err
+	}
+
+	c, err := u.cidBuilder.Sum(content)
+	if err != nil {
+		return "", err
+	}
+
+	link = fmt.Sprintf("file://%s/%s", u.root, c)
+	uploadPath := filepath.Join(u.root, c.String())
+	_, err = os.Stat(uploadPath)
+	if err != nil && !os.IsNotExist(err) {
+		return "", err
+	} else if err == nil {
+		return link, nil
+	}
+
+	f, err := os.Create(uploadPath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, bytes.NewReader(content))
+	if err != nil {
+		return "", err
+	}
+
+	return link, nil
+}

--- a/uploaders/s3uploader/uploader.go
+++ b/uploaders/s3uploader/uploader.go
@@ -65,6 +65,10 @@ func New(client *http.Client, settings S3UploaderSettings) (p2plab.Uploader, err
 	}, nil
 }
 
+func (u *uploader) Close() error {
+	return nil
+}
+
 func (u *uploader) Upload(ctx context.Context, r io.Reader) (link string, err error) {
 	content, err := ioutil.ReadAll(r)
 	if err != nil {

--- a/uploaders/uploaders.go
+++ b/uploaders/uploaders.go
@@ -20,18 +20,24 @@ import (
 	"github.com/Netflix/p2plab"
 	"github.com/Netflix/p2plab/errdefs"
 	"github.com/Netflix/p2plab/pkg/httputil"
+	"github.com/Netflix/p2plab/uploaders/fileuploader"
 	"github.com/Netflix/p2plab/uploaders/s3uploader"
 	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
 )
 
 type UploaderSettings struct {
 	Client *httputil.Client
+	Logger *zerolog.Logger
 	S3     s3uploader.S3UploaderSettings
+	File   fileuploader.FileUploaderSettings
 }
 
 func GetUploader(root, uploaderType string, settings UploaderSettings) (p2plab.Uploader, error) {
 	root = filepath.Join(root, uploaderType)
 	switch uploaderType {
+	case "file":
+		return fileuploader.New(root, settings.Logger, settings.File)
 	case "s3":
 		return s3uploader.New(settings.Client.HTTPClient, settings.S3)
 	default:


### PR DESCRIPTION
Closes #4 

```sh
$ labctl node ls nflx
+----------------------+-----------+--------------+---------------------------------------------------+---------------+---------------+
|          ID          |  ADDRESS  | GITREFERENCE |                      LABELS                       |   CREATEDAT   |   UPDATEDAT   |
+----------------------+-----------+--------------+---------------------------------------------------+---------------+---------------+
| bljgk5vic6vdc56813e0 | 127.0.0.1 | inmemory     | bljgk5vic6vdc56813e0,new-peers,t2.micro,us-west-2 | 7 minutes ago | 5 minutes ago |
| bljgk5vic6vdc56813eg | 127.0.0.1 | inmemory     | bljgk5vic6vdc56813eg,t2.micro,us-west-2           | 7 minutes ago | 5 minutes ago |
| bljgk5vic6vdc56813f0 | 127.0.0.1 | inmemory     | bljgk5vic6vdc56813f0,t2.micro,us-west-2           | 7 minutes ago | 5 minutes ago |
+----------------------+-----------+--------------+---------------------------------------------------+---------------+---------------+
```

```sh
11:16PM INF Completed benchmark "nflx-new-peers-1567034175149975676"
# Summary
Total time: 11 seconds 240 milliseconds
Trace:

# Bandwidth
+-------------+----------------------+---------+----------+----------+---------+
|    QUERY    |         NODE         | TOTALIN | TOTALOUT |  RATEIN  | RATEOUT |
+-------------+----------------------+---------+----------+----------+---------+
| 'new-peers' | bljgk5vic6vdc56813e0 | 420 MB  |  219 kB  | 40 MB/s  | 20 kB/s |
+-------------+----------------------+---------+----------+----------+---------+
|      -      | bljgk5vic6vdc56813eg | 318 MB  |  301 MB  | 8.9 kB/s | 17 MB/s |
+             +----------------------+---------+----------+----------+---------+
|             | bljgk5vic6vdc56813f0 | 412 MB  |  232 MB  | 13 kB/s  | 23 MB/s |
+-------------+----------------------+---------+----------+----------+---------+
|                      TOTAL         | 1.2 GB  |  533 MB  | 40 MB/S  | 40 MB/S |
+-------------+----------------------+---------+----------+----------+---------+
```