### PR TITLE
Implement more aggressive DAG walker

### DIFF
--- a/dag/walker.go
+++ b/dag/walker.go
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package approuter
+package dag
 
 import (
 	"context"
 
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
+	"golang.org/x/sync/errgroup"
 )
 
 func Walk(ctx context.Context, c cid.Cid, dserv ipld.DAGService) error {
@@ -41,8 +42,8 @@ func Walk(ctx context.Context, c cid.Cid, dserv ipld.DAGService) error {
 		}
 
 		child := ndOpt.Node.Cid()
-		eg.Go(func() {
-			return Walk(ctx, child, dserv)
+		eg.Go(func() error {
+			return Walk(gctx, child, dserv)
 		})
 	}
 

--- a/dag/walker.go
+++ b/dag/walker.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package approuter
+
+import (
+	"context"
+
+	cid "github.com/ipfs/go-cid"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+func Walk(ctx context.Context, c cid.Cid, dserv ipld.DAGService) error {
+	nd, err := dserv.Get(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	var cids []cid.Cid
+	for _, link := range nd.Links() {
+		cids = append(cids, link.Cid)
+	}
+
+	eg, gctx := errgroup.WithContext(ctx)
+
+	ndChan := dserv.GetMany(ctx, cids)
+	for ndOpt := range ndChan {
+		if ndOpt.Err != nil {
+			return err
+		}
+
+		child := ndOpt.Node.Cid()
+		eg.Go(func() {
+			return Walk(ctx, child, dserv)
+		})
+	}
+
+	err = eg.Wait()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/labapp/approuter/router.go
+++ b/labapp/approuter/router.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/Netflix/p2plab/daemon"
+	"github.com/Netflix/p2plab/dag"
 	"github.com/Netflix/p2plab/errdefs"
 	"github.com/Netflix/p2plab/metadata"
 	"github.com/Netflix/p2plab/peer"

--- a/labapp/approuter/router.go
+++ b/labapp/approuter/router.go
@@ -27,7 +27,6 @@ import (
 	"github.com/Netflix/p2plab/peer"
 	"github.com/Netflix/p2plab/pkg/logutil"
 	cid "github.com/ipfs/go-cid"
-	dag "github.com/ipfs/go-merkledag"
 	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	multiaddr "github.com/multiformats/go-multiaddr"
@@ -111,7 +110,7 @@ func (s *router) getFile(ctx context.Context, target string) error {
 		return errors.Wrapf(errdefs.ErrInvalidArgument, "%s", err)
 	}
 
-	err = dag.FetchGraph(ctx, c, s.peer.DAGService())
+	err = dag.Walk(ctx, c, s.peer.DAGService())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #19 

Before
---

```
# Summary
Total time: 3 seconds 584 milliseconds
Trace: http://localhost:16686/trace/7095ca5a3799944d?uiFind=7095ca5a3799944d

# Bandwidth
+-------------------+----------------------+---------+----------+----------+----------+
|       QUERY       |         NODE         | TOTALIN | TOTALOUT |  RATEIN  | RATEOUT  |
+-------------------+----------------------+---------+----------+----------+----------+
| (not 'neighbors') | blomnqnic6v9v9b5e1t0 | 298 MB  |  157 kB  | 85 MB/s  | 44 kB/s  |
+-------------------+----------------------+---------+----------+----------+----------+
|         -         | blomnqnic6v9v9b5e1tg | 341 MB  |  300 MB  | 2.4 MB/s | 85 MB/s  |
+                   +----------------------+---------+----------+----------+----------+
|                   | blomnqnic6v9v9b5e1u0 | 309 MB  |  32 MB   | 2.7 MB/s | 453 kB/s |
+-------------------+----------------------+---------+----------+----------+----------+
|                            TOTAL         | 948 MB  |  332 MB  | 90 MB/s  | 86 MB/s  |
+-------------------+----------------------+---------+----------+----------+----------+

# Bitswap
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|       QUERY       |         NODE         | BLOCKSRECV | BLOCKSSENT | DUPBLOCKS | DATARECV | DATASENT | DUPDATA |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
| (not 'neighbors') | blomnqnic6v9v9b5e1t0 |   1,198    |     0      |     0     |  308 MB  |   0 B    |   0 B   |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|         -         | blomnqnic6v9v9b5e1tg |   1,339    |   1,198    |    141    |  341 MB  |  308 MB  |  32 MB  |
+                   +----------------------+------------+------------+-----------+----------+----------+---------+
|                   | blomnqnic6v9v9b5e1u0 |   1,198    |    141     |     0     |  308 MB  |  32 MB   |   0 B   |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|                            TOTAL         |   3,735    |   1,339    |    141    |  958 MB  |  341 MB  |  32 MB  |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
```

After
---

```
# Summary
Total time: 2 seconds 807 milliseconds
Trace: http://localhost:16686/trace/356729b82a4c154e?uiFind=356729b82a4c154e

# Bandwidth
+-------------------+----------------------+---------+----------+----------+----------+
|       QUERY       |         NODE         | TOTALIN | TOTALOUT |  RATEIN  | RATEOUT  |
+-------------------+----------------------+---------+----------+----------+----------+
| (not 'neighbors') | blomnqnic6v9v9b5e1t0 | 375 MB  |  188 kB  | 181 MB/s | 88 kB/s  |
+-------------------+----------------------+---------+----------+----------+----------+
|         -         | blomnqnic6v9v9b5e1tg | 312 MB  |  218 MB  | 16 MB/s  | 99 MB/s  |
+                   +----------------------+---------+----------+----------+----------+
|                   | blomnqnic6v9v9b5e1u0 | 329 MB  |  186 MB  | 18 MB/s  | 88 MB/s  |
+-------------------+----------------------+---------+----------+----------+----------+
|                            TOTAL         | 1.0 GB  |  404 MB  | 215 MB/s | 186 MB/s |
+-------------------+----------------------+---------+----------+----------+----------+

# Bitswap
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|       QUERY       |         NODE         | BLOCKSRECV | BLOCKSSENT | DUPBLOCKS | DATARECV | DATASENT | DUPDATA |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
| (not 'neighbors') | blomnqnic6v9v9b5e1t0 |   1,957    |     0      |    24     |  504 MB  |   0 B    | 4.2 MB  |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|         -         | blomnqnic6v9v9b5e1tg |   1,220    |   1,097    |    22     |  312 MB  |  281 MB  | 3.8 MB  |
+                   +----------------------+------------+------------+-----------+----------+----------+---------+
|                   | blomnqnic6v9v9b5e1u0 |   1,281    |    965     |    83     |  329 MB  |  247 MB  |  20 MB  |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
|                            TOTAL         |   4,458    |   2,062    |    129    |  1.1 GB  |  528 MB  |  28 MB  |
+-------------------+----------------------+------------+------------+-----------+----------+----------+---------+
```