### PR TITLE
Try out go-libp2p-noise@begin-noise

### DIFF
--- a/cmd/labapp/command/root.go
+++ b/cmd/labapp/command/root.go
@@ -62,7 +62,7 @@ func App(ctx context.Context) *cli.App {
 		},
 		cli.StringSliceFlag{
 			Name:   "libp2p-security-transports",
-			Usage:  "security transports for libp2p [tls, secio]",
+			Usage:  "security transports for libp2p [tls, secio, noise]",
 			EnvVar: "LABAPP_LIBP2P_SECURITY_TRANSPORTS",
 		},
 		cli.StringFlag{

--- a/cmd/labctl/command/node.go
+++ b/cmd/labctl/command/node.go
@@ -98,7 +98,7 @@ var nodeCommand = cli.Command{
 				},
 				cli.StringSliceFlag{
 					Name:  "security-transports,st",
-					Usage: "Security transports for libp2p [tls, secio]",
+					Usage: "Security transports for libp2p [tls, secio, noise]",
 				},
 				cli.StringFlag{
 					Name:  "routing,r",

--- a/cmd/ociadd/main.go
+++ b/cmd/ociadd/main.go
@@ -61,9 +61,9 @@ func run(ref string) error {
 	}
 
 	p, err := peer.New(ctx, filepath.Join(root, "peer"), 0, metadata.PeerDefinition{
-		Transports:         []string{"quic"},
+		Transports:         []string{"tcp"},
 		Muxers:             []string{"mplex"},
-		SecurityTransports: []string{"secio"},
+		SecurityTransports: []string{"noise"},
 		Routing:            "nil",
 	})
 	if err != nil {

--- a/cmd/ociget/main.go
+++ b/cmd/ociget/main.go
@@ -66,7 +66,7 @@ func run(addr, ref string) error {
 	p, err := peer.New(ctx, filepath.Join(root, "peer"), 0, metadata.PeerDefinition{
 		Transports:         []string{"tcp", "ws", "quic"},
 		Muxers:             []string{"mplex", "yamux"},
-		SecurityTransports: []string{"tls", "secio"},
+		SecurityTransports: []string{"tls", "secio", "noise"},
 		Routing:            "nil",
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Netflix/p2plab
 go 1.12
 
 require (
+	github.com/ChainSafe/go-libp2p-noise v0.0.0-20190827074707-1d6cd715b817
 	github.com/Microsoft/go-winio v0.4.13-0.20190408173621-84b4ab48a507 // indirect
 	github.com/Microsoft/hcsshim v0.8.6 // indirect
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
@@ -33,8 +34,9 @@ require (
 	github.com/ipfs/go-ipld-format v0.0.2
 	github.com/ipfs/go-merkledag v0.2.3
 	github.com/ipfs/go-unixfs v0.2.1
-	github.com/libp2p/go-libp2p v0.3.0
+	github.com/libp2p/go-libp2p v0.3.1
 	github.com/libp2p/go-libp2p-core v0.2.2
+	github.com/libp2p/go-libp2p-crypto v0.1.0
 	github.com/libp2p/go-libp2p-kad-dht v0.2.0
 	github.com/libp2p/go-libp2p-mplex v0.2.1
 	github.com/libp2p/go-libp2p-peer v0.2.0
@@ -68,7 +70,6 @@ require (
 	github.com/urfave/cli v1.20.0
 	go.etcd.io/bbolt v1.3.3
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/grpc v1.20.1 // indirect
 	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,11 @@ github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33 h1:2/E2IVdZoH
 github.com/AndreasBriese/bbloom v0.0.0-20190823232136-616930265c33/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/ChainSafe/go-libp2p-noise v0.0.0-20190825074726-40ed9eccb6a9 h1:dNdxWAHRKZbDmliImCeeOlGC9h/PeMaCODaI9FjIoSo=
+github.com/ChainSafe/go-libp2p-noise v0.0.0-20190825074726-40ed9eccb6a9/go.mod h1:brqsNqWeSO1CpXjHqRBNTVUTTzabxwRZPGqPVHD05ws=
+github.com/ChainSafe/go-libp2p-noise v0.0.0-20190827074707-1d6cd715b817 h1:6IkYBecHEzXuVQJWQacVvZB+1TtNPFgYjPACzsyp1/4=
+github.com/ChainSafe/go-libp2p-noise v0.0.0-20190827074707-1d6cd715b817/go.mod h1:brqsNqWeSO1CpXjHqRBNTVUTTzabxwRZPGqPVHD05ws=
+github.com/ChainSafe/log15 v1.0.0/go.mod h1:5v1+ALHtdW0NfAeeoYyKmzCAMcAeqkdhIg4uxXWIgOg=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/Kubuxu/gocovmerge v0.0.0-20161216165753-7ecaa51963cd/go.mod h1:bqoB8kInrTeEtYAwaIXoSRqdwnjQmFhsfusnzyui6yY=
 github.com/Microsoft/go-winio v0.4.13-0.20190408173621-84b4ab48a507 h1:QeteIkN4WmQcflYv2SINj79dlbN22KqsfZHZruD8JXw=
@@ -130,6 +135,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/check v0.0.0-20180506172741-cfe4005ccda2/go.mod h1:k9Qvh+8juN+UKMCS/3jFtGICgW8O96FVaZsaxdzDkR4=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
@@ -379,6 +386,8 @@ github.com/libp2p/go-libp2p v0.1.0/go.mod h1:6D/2OBauqLUoqcADOJpn9WbKqvaM07tDw68
 github.com/libp2p/go-libp2p v0.1.1/go.mod h1:I00BRo1UuUSdpuc8Q2mN7yDF/oTUTRAX6JWpTiK9Rp8=
 github.com/libp2p/go-libp2p v0.3.0 h1:XhYEJKmIdi4U4Zbie/ym9k6lqgg3PHM2stGS/cOUDWk=
 github.com/libp2p/go-libp2p v0.3.0/go.mod h1:J7DPB1+zB5VLc8v/kKSD8+u2cbyIGI0Dh/Pf3Wprt+0=
+github.com/libp2p/go-libp2p v0.3.1 h1:opd8/1Sm9zFG37LzNQsIzMTMeBabhlcX5VlvLrNZPV0=
+github.com/libp2p/go-libp2p v0.3.1/go.mod h1:e6bwxbdYH1HqWTz8faTChKGR0BjPc8p+6SyP8GTTR7Y=
 github.com/libp2p/go-libp2p-autonat v0.0.2/go.mod h1:fs71q5Xk+pdnKU014o2iq1RhMs9/PMaG5zXRFNnIIT4=
 github.com/libp2p/go-libp2p-autonat v0.0.6/go.mod h1:uZneLdOkZHro35xIhpbtTzLlgYturpu4J5+0cZK3MqE=
 github.com/libp2p/go-libp2p-autonat v0.1.0 h1:aCWAu43Ri4nU0ZPO7NyLzUvvfqd0nE3dX0R/ZGYVgOU=
@@ -448,6 +457,8 @@ github.com/libp2p/go-libp2p-net v0.0.2/go.mod h1:Yt3zgmlsHOgUWSXmt5V/Jpz9upuJBE8
 github.com/libp2p/go-libp2p-netutil v0.0.1/go.mod h1:GdusFvujWZI9Vt0X5BKqwWWmZFxecf9Gt03cKxm2f/Q=
 github.com/libp2p/go-libp2p-netutil v0.1.0 h1:zscYDNVEcGxyUpMd0JReUZTrpMfia8PmLKcKF72EAMQ=
 github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCThNdbQD54k3TqjpbFU=
+github.com/libp2p/go-libp2p-noise v0.0.0-20190823200153-4f1b35c795df h1:Af9OWF7yaEpGepr9L/sBjELn8elKKXnA1EH77ekGPzI=
+github.com/libp2p/go-libp2p-noise v0.0.0-20190823200153-4f1b35c795df/go.mod h1:O6/CB3dWZ/nSJphIhrOiacCjHJBG4GZHt0Z5fXooTVU=
 github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
 github.com/libp2p/go-libp2p-peer v0.1.1/go.mod h1:jkF12jGB4Gk/IOo+yomm+7oLWxF278F7UnrYUQ1Q8es=
 github.com/libp2p/go-libp2p-peer v0.2.0 h1:EQ8kMjaCUwt/Y5uLgjT8iY2qg0mGUT0N1zUjer50DsY=

--- a/labd/labd.go
+++ b/labd/labd.go
@@ -90,7 +90,7 @@ func New(root, addr string, logger *zerolog.Logger, opts ...LabdOption) (*Labd, 
 	seeder, err := peer.New(sctx, filepath.Join(root, "seeder"), settings.Libp2pPort, metadata.PeerDefinition{
 		Transports:         []string{"tcp", "ws", "quic"},
 		Muxers:             []string{"mplex", "yamux"},
-		SecurityTransports: []string{"secio", "tls"},
+		SecurityTransports: []string{"tls", "secio", "noise"},
 		Routing:            "nil",
 	})
 	if err != nil {

--- a/peer/libp2p.go
+++ b/peer/libp2p.go
@@ -18,12 +18,15 @@ import (
 	"context"
 	"fmt"
 
+	noise "github.com/ChainSafe/go-libp2p-noise"
 	"github.com/Netflix/p2plab/errdefs"
 	"github.com/Netflix/p2plab/metadata"
 	nilrouting "github.com/ipfs/go-ipfs-routing/none"
 	libp2p "github.com/libp2p/go-libp2p"
+	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	host "github.com/libp2p/go-libp2p-core/host"
 	metrics "github.com/libp2p/go-libp2p-core/metrics"
+	libp2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/routing"
 	kaddht "github.com/libp2p/go-libp2p-kad-dht"
 	mplex "github.com/libp2p/go-libp2p-mplex"
@@ -119,9 +122,15 @@ func NewSecurityOption(securityType string) (libp2p.Option, error) {
 		return libp2p.Security(tls.ID, tls.New), nil
 	case "secio":
 		return libp2p.Security(secio.ID, secio.New), nil
+	case "noise":
+		return libp2p.Security(noise.ID, NewNoise), nil
 	default:
 		return nil, errors.Wrapf(errdefs.ErrInvalidArgument, "security %q", securityType)
 	}
+}
+
+func NewNoise(sk crypto.PrivKey, pid libp2ppeer.ID) (*noise.Transport, error) {
+	return noise.NewTransport(pid, sk, false, nil), nil
 }
 
 func NewRoutingOption(ctx context.Context, routingType string) (libp2p.Option, routing.ContentRouting, error) {


### PR DESCRIPTION
Trying out a new secure transport from ChainSafe: https://github.com/ChainSafe/go-libp2p-noise/blob/master/go-libp2p-noise-ethberlin-1a.pdf

Test transferring OCI image over `tcp` + `mplex` + `noise`:
---
```sh
$ git clone git@github.com:Netflix/p2plab.git

$ cd p2plab

$ git checkout libp2p-noise

$ export GO111MODULE=on

$ go run ./cmd/ociadd docker.io/library/alpine:latest
7:01PM INF Starting libp2p peer id=QmdtV78HZThEvVLrGyW3uEZYTLj57TfPR6uVDHRra2KP8q listen=["/ip4/127.0.0.1/tcp/41159","/ip4/192.168.87.35/tcp/41159","/ip4/192.168.122.1/tcp/41159","/ip4/172.17.0.1/tcp/41159","/ip4/192.168.1.6/tcp/41159"]
7:01PM INF Converted OCI image to IPLD DAG cid=bafybeifbgj6mwrb5zg7yekykmeb73tpqowcd5tkevdnurbnmlxaxm7ha5a ref=docker.io/library/alpine:latest
7:01PM INF Retrieve manifest from another p2plab/peer by running:

go run ./cmd/ociget /ip4/127.0.0.1/tcp/41159/p2p/QmdtV78HZThEvVLrGyW3uEZYTLj57TfPR6uVDHRra2KP8q bafybeifbgj6mwrb5zg7yekykmeb73tpqowcd5tkevdnurbnmlxaxm7ha5a

7:01PM INF Connect to this peer from IPFS daemon:

ipfs swarm connect /ip4/127.0.0.1/tcp/41159/p2p/QmdtV78HZThEvVLrGyW3uEZYTLj57TfPR6uVDHRra2KP8q
ipfs cat bafybeifbgj6mwrb5zg7yekykmeb73tpqowcd5tkevdnurbnmlxaxm7ha5a

Press 'Enter' to terminate peer...
```

```sh
$ export GO111MODULE=on

$ go run ./cmd/ociget /ip4/127.0.0.1/tcp/41159/p2p/QmdtV78HZThEvVLrGyW3uEZYTLj57TfPR6uVDHRra2KP8q bafybeifbgj6mwrb5zg7yekykmeb73tpqowcd5tkevdnurbnmlxaxm7ha5a
7:01PM INF Starting libp2p peer id=QmUH3yZLjfLJNbKMXtPKrzNMYS1YG7bQDCeheRBkefduc1 listen=["/ip4/127.0.0.1/tcp/46731/ws","/ip4/192.168.87.35/tcp/46731/ws","/ip4/192.168.122.1/tcp/46731/ws","/ip4/172.17.0.1/tcp/46731/ws","/ip4/192.168.1.6/tcp/46731/ws","/ip4/127.0.0.1/udp/51444/quic","/ip4/192.168.87.35/udp/51444/quic","/ip4/192.168.122.1/udp/51444/quic","/ip4/172.17.0.1/udp/51444/quic","/ip4/192.168.1.6/udp/51444/quic","/ip4/127.0.0.1/tcp/33373","/ip4/192.168.87.35/tcp/33373","/ip4/192.168.122.1/tcp/33373","/ip4/172.17.0.1/tcp/33373","/ip4/192.168.1.6/tcp/33373"]
7:01PM INF Connected to peer addr=/ip4/127.0.0.1/tcp/41159/ipfs/QmdtV78HZThEvVLrGyW3uEZYTLj57TfPR6uVDHRra2KP8q
7:01PM INF Found file in unixfs directory name=sha256:71fe3723a9951fa7523d58253eb59d75a93269f2938a6229419de32e8f92b928
7:01PM INF Found file in unixfs directory name=sha256:778bd6b2922bd8c71c5ca7b5f4478c9e9bddb12ddf67ff0a575adb538a06d0e6
Press 'Enter' to terminate peer...
```

Test transferring `docker.io/library/golang:latest` from two `neighbors` peers using `inmemory` driver:
---
```sh
$ export GO111MODULE=on

$ go run ./cmd/labd
```

```sh
$ export GO111MODULE=on

$ go install ./cmd/labctl

$ labctl cluster create --definition examples/cluster/same-region.json same-region
6:54PM INF Creating node group name=same-region
6:54PM INF Updating metadata with new nodes name=same-region
6:54PM INF Waiting for healthy nodes name=same-region
6:54PM INF Updating cluster metadata name=same-region
6:54PM INF Created cluster "same-region"
same-region

$ labctl node update --ref libp2p-noise --security-transports noise same-region
+----------------------+-----------+--------------+---------------------------------------------------+----------------+-----------+
|          ID          |  ADDRESS  | GITREFERENCE |                      LABELS                       |   CREATEDAT    | UPDATEDAT |
+----------------------+-----------+--------------+---------------------------------------------------+----------------+-----------+
| blpvpv7ic6vf7a3g5in0 | 127.0.0.1 | libp2p-noise | blpvpv7ic6vf7a3g5in0,t2.micro,us-west-2           | 54 seconds ago | now       |
| blpvpvfic6vf7a3g5ing | 127.0.0.1 | libp2p-noise | blpvpvfic6vf7a3g5ing,neighbors,t2.micro,us-west-2 | 54 seconds ago | now       |
| blpvpvnic6vf7a3g5io0 | 127.0.0.1 | libp2p-noise | blpvpvnic6vf7a3g5io0,neighbors,t2.micro,us-west-2 | 54 seconds ago | now       |
+----------------------+-----------+--------------+---------------------------------------------------+----------------+-----------+

$ labctl --output json node ls same-region | jq '.[0].Peer'
{
  "GitReference": "libp2p-noise",
  "Transports": [
    "tcp"
  ],
  "Muxers": [
    "mplex"
  ],
  "SecurityTransports": [
    "noise"
  ],
  "Routing": "nil"
}

$ labctl scenario create examples/scenario/neighbors.json
6:57PM INF Created scenario "neighbors"
neighbors

$ labctl benchmark create same-region neighbors
6:57PM INF Retrieving nodes in cluster bid=same-region-neighbors-1567882651553383197
6:57PM INF Resolving git references bid=same-region-neighbors-1567882651553383197
6:57PM INF Building p2p app(s) bid=same-region-neighbors-1567882651553383197 commits=["e13af9d394498f55acdb7951b122ca99ac9816f1"]
6:57PM INF Updating cluster bid=same-region-neighbors-1567882651553383197
6:57PM INF Retrieving peer infos bid=same-region-neighbors-1567882651553383197
6:57PM INF Connecting cluster bid=same-region-neighbors-1567882651553383197
6:57PM INF Creating scenario plan bid=same-region-neighbors-1567882651553383197
6:57PM INF Transforming objects into IPLD DAGs bid=same-region-neighbors-1567882651553383197
6:57PM INF Resolving OCI reference bid=same-region-neighbors-1567882651553383197 source=docker.io/library/golang:latest
6:57PM INF Resolved reference to digest bid=same-region-neighbors-1567882651553383197 digest=sha256:30101c5d45c7b68c2233962251da3d599417055e5ad73b84b7c4323b11caf57e source=docker.io/library/golang:latest
6:57PM INF Converting manifest recursively to IPLD DAG bid=same-region-neighbors-1567882651553383197 digest=sha256:30101c5d45c7b68c2233962251da3d599417055e5ad73b84b7c4323b11caf57e
6:58PM INF Constructing Unixfs directory over manifest blobs bid=same-region-neighbors-1567882651553383197 target=sha256:e7c6d1d3c099cc16fbee65106b15abd03ad54645702e3204054d4a27e986b31a
6:58PM INF Planning scenario seed bid=same-region-neighbors-1567882651553383197
6:58PM INF Planning scenario benchmark bid=same-region-neighbors-1567882651553383197
6:58PM INF Creating benchmark metadata bid=same-region-neighbors-1567882651553383197
6:58PM INF Executing scenario plan bid=same-region-neighbors-1567882651553383197
6:58PM INF Seeding cluster bid=same-region-neighbors-1567882651553383197
6:58PM INF Seeding cluster bid=same-region-neighbors-1567882651553383197 elapsed="20 seconds"
6:58PM INF Seeding cluster bid=same-region-neighbors-1567882651553383197 elapsed="40 seconds"
6:59PM INF Seeding cluster bid=same-region-neighbors-1567882651553383197 elapsed="1 minute"
// ...
```

Unfortunately, it doesn't seem to successfully complete atm.